### PR TITLE
Fix acronym preservation in case conversions (e.g., DBClusters → db-c…

### DIFF
--- a/src/awsquery/case_utils.py
+++ b/src/awsquery/case_utils.py
@@ -35,9 +35,9 @@ def to_snake_case(text: str) -> str:
         return text.replace("-", "_").lower()
 
     # Handle PascalCase/camelCase with acronym preservation
-    # Pattern 1: Insert underscore before uppercase followed by lowercase
-    # Handles: "HTTPSListener" -> "HTTPS_Listener"
-    s1 = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", text)
+    # Pattern 1: Split before the last capital when followed by lowercase
+    # Handles: "HTTPSListener" -> "HTTPS_Listener", "DBClusters" -> "DB_Clusters"
+    s1 = re.sub("([A-Z]+)([A-Z][a-z])", r"\1_\2", text)
 
     # Pattern 2: Insert underscore before uppercase after lowercase/digit
     # Handles: "VPCId" -> "VPC_Id", "load2Balancer" -> "load2_Balancer"

--- a/src/awsquery/cli.py
+++ b/src/awsquery/cli.py
@@ -505,7 +505,7 @@ def find_hint_function(hint, service, session=None):
         # Create mapping of CLI format to original operation names
         operation_mapping = {}
         for op in available_operations:
-            cli_format = op.replace("_", "-").lower()
+            cli_format = to_kebab_case(op)
             operation_mapping[cli_format] = op
 
         # Find all matches using the enhanced validator with function_hint
@@ -585,7 +585,7 @@ def action_completer(prefix, parsed_args, **kwargs):
         cli_operations = []
         for op in operations:
             if op in valid_operations:
-                kebab_case = re.sub("([a-z0-9])([A-Z])", r"\1-\2", op).lower()
+                kebab_case = to_kebab_case(op)
                 cli_operations.append(kebab_case)
 
         # Return all valid operations - let argcomplete validator handle filtering

--- a/tests/unit/test_input_hint_parameter.py
+++ b/tests/unit/test_input_hint_parameter.py
@@ -1086,3 +1086,83 @@ class TestCrossServiceHints:
             assert field is None
             assert limit is None
             assert alternatives == []
+
+
+class TestFindHintFunctionAcronymHandling:
+    def test_find_hint_function_matches_db_operations(self):
+        from awsquery.cli import find_hint_function
+
+        with patch("awsquery.cli.get_service_valid_operations") as mock_valid_ops:
+            with patch("awsquery.cli.get_service_operations") as mock_all_ops:
+                mock_all_ops.return_value = [
+                    "DescribeDBClusters",
+                    "DescribeDBInstances",
+                    "DescribeDBSnapshots",
+                    "CreateDBCluster",
+                ]
+                mock_valid_ops.return_value = [
+                    "DescribeDBClusters",
+                    "DescribeDBInstances",
+                    "DescribeDBSnapshots",
+                ]
+
+                service, function, field, limit, alternatives = find_hint_function(
+                    "desc-db-clus", "rds"
+                )
+
+                assert function == "DescribeDBClusters"
+                assert "DescribeDBInstances" not in alternatives
+                assert "DescribeDBSnapshots" not in alternatives
+
+    def test_find_hint_function_matches_vpc_operations(self):
+        from awsquery.cli import find_hint_function
+
+        with patch("awsquery.cli.get_service_valid_operations") as mock_valid_ops:
+            with patch("awsquery.cli.get_service_operations") as mock_all_ops:
+                mock_all_ops.return_value = [
+                    "DescribeVpcs",
+                    "DescribeVpcEndpoints",
+                    "DescribeVpcAttribute",
+                    "CreateVpc",
+                ]
+                mock_valid_ops.return_value = [
+                    "DescribeVpcs",
+                    "DescribeVpcEndpoints",
+                    "DescribeVpcAttribute",
+                ]
+
+                service, function, field, limit, alternatives = find_hint_function(
+                    "desc-vpc", "ec2"
+                )
+
+                assert function == "DescribeVpcs"
+                assert "DescribeVpcAttribute" in alternatives
+                assert "DescribeVpcEndpoints" in alternatives
+
+    def test_find_hint_function_returns_correct_alternatives(self):
+        from awsquery.cli import find_hint_function
+
+        with patch("awsquery.cli.get_service_valid_operations") as mock_valid_ops:
+            with patch("awsquery.cli.get_service_operations") as mock_all_ops:
+                mock_all_ops.return_value = [
+                    "DescribeDBClusters",
+                    "DescribeDBClusterSnapshots",
+                    "DescribeDBClusterEndpoints",
+                    "DescribeDBClusterParameters",
+                ]
+                mock_valid_ops.return_value = [
+                    "DescribeDBClusters",
+                    "DescribeDBClusterSnapshots",
+                    "DescribeDBClusterEndpoints",
+                    "DescribeDBClusterParameters",
+                ]
+
+                service, function, field, limit, alternatives = find_hint_function(
+                    "desc-db-clus", "rds"
+                )
+
+                assert function == "DescribeDBClusters"
+                assert len(alternatives) == 3
+                assert "DescribeDBClusterSnapshots" in alternatives
+                assert "DescribeDBClusterEndpoints" in alternatives
+                assert "DescribeDBClusterParameters" in alternatives


### PR DESCRIPTION
…lusters)