### PR TITLE
Fix remaining 15 broken $-suffix entries surfaced by audit

### DIFF
--- a/.issues/e1bzl-fix-remaining-15-broken-suffix-entries-surfaced-by-audit/EXECUTION.html
+++ b/.issues/e1bzl-fix-remaining-15-broken-suffix-entries-surfaced-by-audit/EXECUTION.html
@@ -1,0 +1,151 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="artifact-source-sha256" content="1ccbd49d12073903df5666b09484324349a3aea62d48a6d0e732588ade93685e">
+<meta name="artifact-source-file" content="EXECUTION.md">
+<meta name="artifact-generated-at" content="2026-06-01 09:57 UTC">
+<meta name="design-system-version" content="ds-1">
+<title>Execution — Fix remaining 15 broken $-suffix entries surfaced by audit</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://flomotlik.github.io/claude-code/design-system.css">
+</head>
+<body>
+<div class="page">
+
+<header class="row">
+  <div class="margin">
+    <p class="kicker"><span class="kicker-num">00</span>Execution</p>
+  </div>
+  <div class="body">
+    <h1 class="masthead-title">Fix remaining 15 broken $-suffix entries surfaced by audit</h1>
+    <p class="masthead-sub">Issue: e1bzl-fix-remaining-15-broken-suffix-entries-surfaced-by-audit &middot; Generated 2026-06-01 09:57 UTC</p>
+  </div>
+</header>
+
+<hr class="rule">
+
+<section class="row" id="strategy">
+  <div class="margin">
+    <p class="kicker"><span class="kicker-num">01</span>Strategy</p>
+  </div>
+  <div class="body">
+    <h2>Strategy summary</h2>
+      <div class="callout callout-ok">
+        <p><strong>Status:</strong> complete. 15 broken <code>$</code>-suffix entries fixed in <code>default_filters.yaml</code> via a single atomic commit. Audit confirms all 15 in-scope entries gone from the BROKEN list; the 6 residual entries are sue5t-scope (will resolve on rebase post-merge).</p>
+      </div>
+      <p>Uniform mechanical fix: 14 entries lose their trailing <code>$</code> so the pattern becomes a contains-match against flattened <code>Foo.0..N</code> keys. The 15th (<code>ssm.get_parameters Parameters$</code>) is deleted because <code>Parameters</code> as contains-match would degenerate to "all columns".</p>
+      <ul>
+        <li><strong>Branch dependency:</strong> e1bzl was cut from main before sue5t merged. The audit script (added in sue5t) ran via a sibling-worktree fallback for verification.</li>
+        <li><strong>One commit:</strong> tasks 1 and 2 logically share scope; CLAUDE.md prescribes combining related changes.</li>
+        <li><strong>No code changes:</strong> only YAML; no test, README, or Python source touched.</li>
+      </ul>
+  </div>
+</section>
+
+<hr class="rule">
+
+<section class="row" id="flow">
+  <div class="margin">
+    <p class="kicker"><span class="kicker-num">02</span>Flow</p>
+  </div>
+  <div class="body">
+    <h2>Task flow &amp; dependencies</h2>
+      <div class="flow">
+      <div class="flow-node">
+        <p class="flow-num">01</p>
+        <p class="flow-title">Tasks 1+2</p>
+        <p class="flow-meta"><code>9d7573e</code></p>
+        <p>Fix 15 broken $-suffix entries surfaced by audit</p>
+      </div>
+      </div>
+      <p class="margin-note">One atomic commit. Verification follows in the same run.</p>
+  </div>
+</section>
+
+<hr class="rule">
+
+<section class="row" id="decisions">
+  <div class="margin">
+    <p class="kicker"><span class="kicker-num">03</span>Decisions</p>
+  </div>
+  <div class="body">
+    <h2>Key decisions &amp; options</h2>
+      <div class="decision">
+        <h3>Tasks 1+2 combined into one commit</h3>
+        <p>PLAN.md split tasks 1 and 2 into two commits; both edit the same logical scope (broken <code>$</code>-suffix entries in <code>default_filters.yaml</code>). Per CLAUDE.md “Combine related changes — one commit for logically grouped changes”, combined into <code>9d7573e</code>. The intermediate state (Task 1 alone) leaves 1 broken entry — not a clean stopping point.</p>
+      </div>
+      <div class="decision">
+        <h3>Audit run from sibling sue5t worktree</h3>
+        <p>Audit script lives on the sue5t branch (introduced there, not yet merged to main). e1bzl branched off main, so the script is absent here. Verification used the sue5t copy with <code>PYTHONPATH=&lt;e1bzl-src&gt;</code> so it loaded the e1bzl YAML. Once sue5t merges and e1bzl rebases, the in-repo audit test gates this fix permanently.</p>
+      </div>
+      <div class="decision">
+        <h3>Direct execution — no specialist agent</h3>
+        <p>Agent-tool executor with <code>isolation: worktree</code> created a doubly-nested sub-worktree; the agent’s CF-034 containment rule correctly refused. For a 3-task mechanical YAML edit, direct orchestrator execution is appropriate. CLAUDE.md’s <code>@agent-python-infra-automator</code> mandate applies to Python code; this task only touched YAML.</p>
+      </div>
+  </div>
+</section>
+
+<hr class="rule">
+
+<section class="row" id="detail">
+  <div class="margin">
+    <p class="kicker"><span class="kicker-num">04</span>Detail</p>
+  </div>
+  <div class="body">
+    <h2>Full detail</h2>
+    <details class="detail">
+      <summary>Show full artifact source
+        <span class="summary-hint">click to expand</span></summary>
+      <div class="detail-body">
+        <pre><code id="artifact-source-target"></code></pre>
+      </div>
+    </details>
+  </div>
+</section>
+
+<hr class="rule">
+
+<section class="row" id="provenance">
+  <div class="margin">
+    <p class="kicker"><span class="kicker-num">05</span>Provenance</p>
+  </div>
+  <div class="body">
+    <h2>Provenance</h2>
+    <p>Generated from the canonical <code>.md</code>. Regenerate with
+       <code>/issue:view</code> if the <code>.md</code> changes.</p>
+    <footer class="footer">
+      <span>Source: <code>EXECUTION.md</code> &middot;
+        SHA-256 <code>1ccbd49d12073903df5666b09484324349a3aea62d48a6d0e732588ade93685e</code></span>
+      <span>Generated 2026-06-01 09:57 UTC &middot; design system ds-1</span>
+    </footer>
+  </div>
+</section>
+
+</div>
+
+<script type="application/json" id="artifact-source">
+{"source": "# Execution: Fix remaining 15 broken $-suffix entries surfaced by audit\n\n**Started:** 2026-06-01T09:55:00Z\n**Completed:** 2026-06-01T10:02:00Z\n**Duration:** ~7 minutes\n**Status:** complete\n**Branch:** e1bzl-fix-remaining-15-broken-suffix-entries-surfaced-by-audit\n\n## Execution Log\n\n- [x] Task 1: Strip `$` from 14 list-of-primitive entries — commit 9d7573e\n- [x] Task 2: Delete `ssm.get_parameters Parameters$` (degenerate filter) — commit 9d7573e\n  (combined with Task 1 per CLAUDE.md \"Combine related changes\" — both tasks scope to one logical YAML cleanup)\n- [x] Task 3: Verify audit + tests — no edits, verification only\n\n## Commits\n\n| Hash      | Subject                                        |\n| :-------- | :--------------------------------------------- |\n| 9d7573e   | Fix 15 broken $-suffix entries surfaced by audit |\n\n## Verification Results\n\n| Gate | Result |\n| :--- | :----- |\n| Audit script (run from sue5t worktree against e1bzl YAML) | **all 15 e1bzl-scope entries gone from BROKEN list** |\n| `make test` | 1307 passed (no test changes in this issue) |\n| `make lint` | flake8 clean, pylint 10.00/10 |\n| `make format-check` | clean (62 files) |\n| `make type-check` | clean (12 source files) |\n\nAudit residual broken list contains only the 6 sue5t-scope entries (`directconnect tags$`, `ec2.describe_vpcs Tags$`, `ecr.describe_images imageTags$`, two `redshift Tags$`, `redshift Key$`). These are fixed on the sue5t branch and will disappear once sue5t merges and e1bzl rebases. **None of the 15 in-scope entries for this issue remain broken.**\n\n## Deviations from Plan\n\n### Tasks 1 + 2 combined into one commit\n\nPLAN.md prescribed 2 commits for the YAML edits. Combined into one commit `9d7573e` because:\n- Both tasks scope to the same logical change (\"fix broken `$`-suffix entries in `default_filters.yaml`\")\n- CLAUDE.md commit guidelines explicitly say \"Combine related changes — One commit for logically grouped changes\"\n- Splitting requires editing the same `ssm.get_parameters` block twice (Task 1's `InvalidParameters$` → `InvalidParameters` strip on the same line range where Task 2 deletes `Parameters$`)\n- The intermediate state (Task 1 alone) leaves 1 broken entry — not a clean stopping point\n\n### Audit run from sibling sue5t worktree\n\nThe audit script `scripts/audit_default_filters.py` was introduced on the sue5t branch and is not yet merged to main. e1bzl branched off main, so the script is not present in this worktree. Verification was performed by:\n\n1. Copying the script from `/workspace/.worktrees/sue5t-…/scripts/audit_default_filters.py` to `/tmp/audit.py`\n2. Running it with `PYTHONPATH=<e1bzl-src>` so it loads the e1bzl YAML via `awsquery.config.load_default_filters`\n3. Confirming the 15 in-scope entries are absent from the BROKEN list\n\nWhen sue5t merges to main and e1bzl rebases, the audit script will be naturally present, and the in-repo test (also added in sue5t) will gate this fix permanently.\n\n### Direct execution (no specialist agent)\n\nThe Agent-tool executor was attempted with `isolation: worktree`, but the harness spawned the agent in a doubly-nested sub-worktree (`.claude/worktrees/agent-<id>/` inside the issue worktree). The agent's hardcoded CF-034 containment rule correctly refused to proceed. For a 3-task mechanical YAML edit, direct execution by the orchestrator is appropriate; the executor-agent abstraction is overhead. CLAUDE.md's `@agent-python-infra-automator` mandate applies to Python code; this task only touched YAML.\n\n## Out-of-scope: no new broken entries surfaced\n\nThe audit's residual 6 BROKEN entries are all sue5t-scope (already fixed on that branch). No new broken entries were discovered while making these edits.\n\n## Self-Check\n\n- [x] 14 list-of-primitive entries: trailing `$` stripped\n- [x] `ssm.get_parameters Parameters$` line deleted (only that one; athena's `Parameters$` correctly preserved)\n- [x] Audit residual broken list contains zero of the 15 in-scope entries\n- [x] `make test`, `make lint`, `make format-check`, `make type-check` all green\n- [x] No other files touched (only `src/awsquery/default_filters.yaml`)\n- [x] No Claude attribution in commits\n- **Result:** PASSED\n"}
+</script>
+
+<script>
+(function () {
+  "use strict";
+  var dataEl = document.getElementById("artifact-source");
+  var target = document.getElementById("artifact-source-target");
+  if (dataEl && target) {
+    try { target.textContent = JSON.parse(dataEl.textContent).source || ""; }
+    catch (e) { target.textContent = dataEl.textContent; }
+  }
+  document.querySelectorAll('a[href^="#"]').forEach(function (a) {
+    a.addEventListener("click", function (ev) {
+      var el = document.getElementById(a.getAttribute("href").slice(1));
+      if (el) { ev.preventDefault(); el.scrollIntoView({ behavior: "smooth" }); }
+    });
+  });
+})();
+</script>
+</body>
+</html>

--- a/.issues/e1bzl-fix-remaining-15-broken-suffix-entries-surfaced-by-audit/EXECUTION.md
+++ b/.issues/e1bzl-fix-remaining-15-broken-suffix-entries-surfaced-by-audit/EXECUTION.md
@@ -1,0 +1,70 @@
+# Execution: Fix remaining 15 broken $-suffix entries surfaced by audit
+
+**Started:** 2026-06-01T09:55:00Z
+**Completed:** 2026-06-01T10:02:00Z
+**Duration:** ~7 minutes
+**Status:** complete
+**Branch:** e1bzl-fix-remaining-15-broken-suffix-entries-surfaced-by-audit
+
+## Execution Log
+
+- [x] Task 1: Strip `$` from 14 list-of-primitive entries — commit 9d7573e
+- [x] Task 2: Delete `ssm.get_parameters Parameters$` (degenerate filter) — commit 9d7573e
+  (combined with Task 1 per CLAUDE.md "Combine related changes" — both tasks scope to one logical YAML cleanup)
+- [x] Task 3: Verify audit + tests — no edits, verification only
+
+## Commits
+
+| Hash      | Subject                                        |
+| :-------- | :--------------------------------------------- |
+| 9d7573e   | Fix 15 broken $-suffix entries surfaced by audit |
+
+## Verification Results
+
+| Gate | Result |
+| :--- | :----- |
+| Audit script (run from sue5t worktree against e1bzl YAML) | **all 15 e1bzl-scope entries gone from BROKEN list** |
+| `make test` | 1307 passed (no test changes in this issue) |
+| `make lint` | flake8 clean, pylint 10.00/10 |
+| `make format-check` | clean (62 files) |
+| `make type-check` | clean (12 source files) |
+
+Audit residual broken list contains only the 6 sue5t-scope entries (`directconnect tags$`, `ec2.describe_vpcs Tags$`, `ecr.describe_images imageTags$`, two `redshift Tags$`, `redshift Key$`). These are fixed on the sue5t branch and will disappear once sue5t merges and e1bzl rebases. **None of the 15 in-scope entries for this issue remain broken.**
+
+## Deviations from Plan
+
+### Tasks 1 + 2 combined into one commit
+
+PLAN.md prescribed 2 commits for the YAML edits. Combined into one commit `9d7573e` because:
+- Both tasks scope to the same logical change ("fix broken `$`-suffix entries in `default_filters.yaml`")
+- CLAUDE.md commit guidelines explicitly say "Combine related changes — One commit for logically grouped changes"
+- Splitting requires editing the same `ssm.get_parameters` block twice (Task 1's `InvalidParameters$` → `InvalidParameters` strip on the same line range where Task 2 deletes `Parameters$`)
+- The intermediate state (Task 1 alone) leaves 1 broken entry — not a clean stopping point
+
+### Audit run from sibling sue5t worktree
+
+The audit script `scripts/audit_default_filters.py` was introduced on the sue5t branch and is not yet merged to main. e1bzl branched off main, so the script is not present in this worktree. Verification was performed by:
+
+1. Copying the script from `/workspace/.worktrees/sue5t-…/scripts/audit_default_filters.py` to `/tmp/audit.py`
+2. Running it with `PYTHONPATH=<e1bzl-src>` so it loads the e1bzl YAML via `awsquery.config.load_default_filters`
+3. Confirming the 15 in-scope entries are absent from the BROKEN list
+
+When sue5t merges to main and e1bzl rebases, the audit script will be naturally present, and the in-repo test (also added in sue5t) will gate this fix permanently.
+
+### Direct execution (no specialist agent)
+
+The Agent-tool executor was attempted with `isolation: worktree`, but the harness spawned the agent in a doubly-nested sub-worktree (`.claude/worktrees/agent-<id>/` inside the issue worktree). The agent's hardcoded CF-034 containment rule correctly refused to proceed. For a 3-task mechanical YAML edit, direct execution by the orchestrator is appropriate; the executor-agent abstraction is overhead. CLAUDE.md's `@agent-python-infra-automator` mandate applies to Python code; this task only touched YAML.
+
+## Out-of-scope: no new broken entries surfaced
+
+The audit's residual 6 BROKEN entries are all sue5t-scope (already fixed on that branch). No new broken entries were discovered while making these edits.
+
+## Self-Check
+
+- [x] 14 list-of-primitive entries: trailing `$` stripped
+- [x] `ssm.get_parameters Parameters$` line deleted (only that one; athena's `Parameters$` correctly preserved)
+- [x] Audit residual broken list contains zero of the 15 in-scope entries
+- [x] `make test`, `make lint`, `make format-check`, `make type-check` all green
+- [x] No other files touched (only `src/awsquery/default_filters.yaml`)
+- [x] No Claude attribution in commits
+- **Result:** PASSED

--- a/.issues/e1bzl-fix-remaining-15-broken-suffix-entries-surfaced-by-audit/ISSUE.md
+++ b/.issues/e1bzl-fix-remaining-15-broken-suffix-entries-surfaced-by-audit/ISSUE.md
@@ -1,0 +1,66 @@
+---
+id: e1bzl
+title: Fix remaining 15 broken $-suffix entries surfaced by audit
+status: open
+priority: medium
+labels:
+- bug
+- filters
+remote:
+- source: github
+  id: '14'
+  url: https://github.com/flomotlik/awsquery/issues/14
+---
+
+## Summary
+
+Follow-up to sue5t. The shape-aware audit script (`scripts/audit_default_filters.py`) introduced in that issue surfaced 15 additional `$`-suffix entries in `default_filters.yaml` that don't match any post-transform field name. All are list-of-primitive fields where the `$` anchor prevents matching against the flattened `Foo.0..N` keys.
+
+## Broken entries
+
+All 15 entries fail with the same root cause (anchored against a name that becomes `<name>.<index>` after flattening). Uniform fix: drop the `$` so the pattern becomes a contains-match. The contains-match captures every flattened index for that field.
+
+| Service / Operation                                  | Entry                  | Line  | Diagnosis                                  |
+| :--------------------------------------------------- | :--------------------- | ----: | :----------------------------------------- |
+| `batch.describe_compute_environments`                | `instanceTypes$`       |  386  | list-of-primitive (deep nesting)           |
+| `ce.get_cost_and_usage`                              | `Keys$`                | (~)   | list-of-primitive at `Groups.Keys.0..N`    |
+| `cloudwatch.list_metrics`                            | `OwningAccounts$`      |  686  | list-of-primitive                          |
+| `ec2.describe_vpc_endpoints`                         | `SubnetIds$`           | 1049  | list-of-primitive                          |
+| `elasticbeanstalk.describe_applications`             | `ConfigurationTemplates$` | 1368  | list-of-primitive                          |
+| `elasticbeanstalk.describe_applications`             | `Versions$`            | 1373  | list-of-primitive                          |
+| `kafka.list_configurations`                          | `kafkaVersions$`       | 1832  | list-of-primitive                          |
+| `route53.get_hosted_zone`                            | `NameServers$`         | 2288  | list-of-primitive at `DelegationSet.NameServers.0..N` |
+| `s3.get_bucket_cors`                                 | `AllowedOrigins$`      | 2333  | list-of-primitive                          |
+| `s3.get_bucket_cors`                                 | `AllowedMethods$`      | 2334  | list-of-primitive                          |
+| `s3.get_bucket_cors`                                 | `AllowedHeaders$`      | 2335  | list-of-primitive                          |
+| `s3.get_bucket_cors`                                 | `ExposeHeaders$`       | 2336  | list-of-primitive                          |
+| `s3.get_bucket_notification_configuration`           | `Events$`              | 2361  | list-of-primitive                          |
+| `ssm.get_parameters`                                 | `InvalidParameters$`   | 2645  | list-of-primitive                          |
+| `ssm.get_parameters`                                 | `Parameters$`          | 2646  | list-of-objects; would match every column  |
+
+## Scope
+
+- `src/awsquery/default_filters.yaml` — single mechanical edit: strip trailing `$` from the 15 lines above.
+- `scripts/audit_default_filters.py` — no change; it already classifies these correctly.
+- Tests — re-run existing `test_audit_default_filters` (Task 7 of sue5t) and confirm the in-scope-after-fix set is empty.
+
+## Special case: `ssm.get_parameters Parameters$`
+
+Dropping `$` makes `Parameters` a contains-match — but the SSM response root is `Parameters: [...]`, so every flattened column begins with `Parameters.`. The contains-match matches all of them, effectively disabling the filter for that operation. Two options:
+
+1. **Drop `$` anyway** — uniform with the other 14. Auto-column selection takes over; user sees a wide table by default. Same outcome as deleting the entry.
+2. **Delete the entry** — explicit acknowledgment that defaults can't meaningfully filter this operation. Cleaner.
+
+Plan picks option 2 (delete) for `Parameters$` only; option 1 (drop `$`) for all 14 others.
+
+## Acceptance Criteria
+
+- [ ] 14 entries: trailing `$` stripped in `default_filters.yaml`
+- [ ] `ssm.get_parameters Parameters$` line deleted (kept `InvalidParameters` and the other 4 entries in that block)
+- [ ] `python3 scripts/audit_default_filters.py` reports `Broken: 0` for the fixed set (the gate test from sue5t passes)
+- [ ] `make test` green
+- [ ] No grammar changes, no new module, no behavior changes elsewhere
+
+## Inherited decisions (from sue5t CONTEXT.md, do not re-litigate)
+
+D5 (static shape-aware audit), D7 (no YAML restructure, in-place edits only). Decisions D1–D4 and D6 are unrelated to this follow-up.

--- a/.issues/e1bzl-fix-remaining-15-broken-suffix-entries-surfaced-by-audit/ISSUE.md
+++ b/.issues/e1bzl-fix-remaining-15-broken-suffix-entries-surfaced-by-audit/ISSUE.md
@@ -1,7 +1,7 @@
 ---
 id: e1bzl
 title: Fix remaining 15 broken $-suffix entries surfaced by audit
-status: open
+status: done
 priority: medium
 labels:
 - bug

--- a/.issues/e1bzl-fix-remaining-15-broken-suffix-entries-surfaced-by-audit/PLAN.md
+++ b/.issues/e1bzl-fix-remaining-15-broken-suffix-entries-surfaced-by-audit/PLAN.md
@@ -1,0 +1,104 @@
+---
+slug: e1bzl-fix-remaining-15-broken-suffix-entries-surfaced-by-audit
+stage: plan
+research: (inherited from sue5t — audit script is the research)
+generated: 2026-06-01
+---
+
+<strategy>
+Mechanical YAML edit. 14 entries lose their trailing `$` (becomes contains-match against flattened `Foo.0..N` keys). 1 entry (`ssm.get_parameters Parameters$`) is deleted because contains-match would degenerate to "all columns". Validated by re-running the existing sue5t-introduced audit script + gate test.
+
+No new code paths, no new files, no behavior change in the filter parser. The fix lives entirely in `default_filters.yaml`.
+</strategy>
+
+<tasks>
+
+<task type="auto" id="1">
+  <title>Strip $ from 14 list-of-primitive entries</title>
+  <files>src/awsquery/default_filters.yaml</files>
+  <action>
+Edit `src/awsquery/default_filters.yaml`. Find each of the following 14 lines and remove only the trailing `$`. Leave indentation, dash, and field name unchanged. Do NOT reorder or restructure.
+
+| Service operation block               | Edit                                                |
+| :------------------------------------ | :-------------------------------------------------- |
+| `batch.describe_compute_environments` | `- instanceTypes$` → `- instanceTypes`              |
+| `ce.get_cost_and_usage`               | `- Keys$` → `- Keys`                                |
+| `cloudwatch.list_metrics`             | `- OwningAccounts$` → `- OwningAccounts`            |
+| `ec2.describe_vpc_endpoints`          | `- SubnetIds$` → `- SubnetIds`                      |
+| `elasticbeanstalk.describe_applications` | `- ConfigurationTemplates$` → `- ConfigurationTemplates` |
+| `elasticbeanstalk.describe_applications` | `- Versions$` → `- Versions`                     |
+| `kafka.list_configurations`           | `- kafkaVersions$` → `- kafkaVersions`              |
+| `route53.get_hosted_zone`             | `- NameServers$` → `- NameServers`                  |
+| `s3.get_bucket_cors`                  | `- AllowedOrigins$` → `- AllowedOrigins`            |
+| `s3.get_bucket_cors`                  | `- AllowedMethods$` → `- AllowedMethods`            |
+| `s3.get_bucket_cors`                  | `- AllowedHeaders$` → `- AllowedHeaders`            |
+| `s3.get_bucket_cors`                  | `- ExposeHeaders$` → `- ExposeHeaders`              |
+| `s3.get_bucket_notification_configuration` | `- Events$` → `- Events`                       |
+| `ssm.get_parameters`                  | `- InvalidParameters$` → `- InvalidParameters`      |
+
+Verify each edit by re-grepping for `$` on those exact field names — must return zero matches after the edit.
+  </action>
+  <verify>
+```bash
+cd /workspace/.worktrees/e1bzl-fix-remaining-15-broken-suffix-entries-surfaced-by-audit
+grep -nE -- "- (instanceTypes|Keys|OwningAccounts|SubnetIds|ConfigurationTemplates|Versions|kafkaVersions|NameServers|AllowedOrigins|AllowedMethods|AllowedHeaders|ExposeHeaders|Events|InvalidParameters)\\\$$" src/awsquery/default_filters.yaml || echo "OK: no anchored variants remain"
+```
+Exit 0 + "OK" line printed = success.
+  </verify>
+  <done>14 specific lines changed; no other edits; grep returns no anchored variants for those exact field names.</done>
+</task>
+
+<task type="auto" id="2">
+  <title>Delete `ssm.get_parameters Parameters$` entry</title>
+  <files>src/awsquery/default_filters.yaml</files>
+  <action>
+Delete the single line `    - Parameters$` inside the `ssm.get_parameters.columns` block. Keep the surrounding entries (`ARN$`, `Name$`, `DataType$`, `Type$`, `InvalidParameters`, `LastModifiedDate$`, `Selector$`) untouched.
+
+Rationale (from ISSUE.md): `Parameters` (no `$`) would contains-match every flattened `Parameters.<N>.<Field>` column, which is effectively no filter. Deletion is cleaner than a degenerate filter.
+  </action>
+  <verify>
+```bash
+cd /workspace/.worktrees/e1bzl-fix-remaining-15-broken-suffix-entries-surfaced-by-audit
+awk '/^  get_parameters:/{flag=1} /^  [a-z_]+:$/&&!/^  get_parameters:/{flag=0} flag' src/awsquery/default_filters.yaml | grep -c "Parameters" || true
+```
+Expected output: 1 (only `InvalidParameters` remains; the bare `Parameters$` line is gone). If output is 2, the delete didn't happen.
+  </verify>
+  <done>Exactly one line removed inside `ssm.get_parameters.columns`; surrounding lines unchanged.</done>
+</task>
+
+<task type="auto" id="3">
+  <title>Run audit + tests, confirm zero broken in the fixed set</title>
+  <files>(verification only)</files>
+  <action>
+Run the audit script and the gate test. Confirm:
+- audit script exits 0
+- the 15 entries fixed in tasks 1 and 2 no longer appear in the broken list
+- `make test` is green (no regressions)
+- `make lint`, `make format-check`, `make type-check` clean
+  </action>
+  <verify>
+```bash
+cd /workspace/.worktrees/e1bzl-fix-remaining-15-broken-suffix-entries-surfaced-by-audit
+python3 scripts/audit_default_filters.py 2>&1 | grep -E "^Broken: |BROKEN" | head -20
+# Expected: 'Broken: 0' OR 'Broken: N' but with NONE of the 15 service/field pairs from the table above
+
+make test    # all 1346+ tests pass (no new fails)
+make lint format-check type-check
+```
+  </verify>
+  <done>Audit shows the 15 service/field pairs are gone from the BROKEN list; all CI gates green.</done>
+</task>
+
+</tasks>
+
+<success_criteria>
+- [x] All 14 list-of-primitive entries: `$` stripped.
+- [x] `ssm.get_parameters Parameters$` entry deleted.
+- [x] Audit script reports `Broken: 0` for the fixed set.
+- [x] `make test`, `make lint`, `make format-check`, `make type-check` all clean.
+- [x] No other files touched.
+</success_criteria>
+
+<commit_format>
+Plain single-line summaries, ≤72 chars, no body, NO Claude attribution trailer. One atomic commit per task (3 commits total). Per user standing memory (`feedback_no_claude_attribution.md`) — overrides any CLAUDE.md trailer example.
+</commit_format>

--- a/src/awsquery/default_filters.yaml
+++ b/src/awsquery/default_filters.yaml
@@ -383,7 +383,7 @@ batch:
     - desiredvCpus$
     - imageId$
     - type$
-    - instanceTypes$
+    - instanceTypes
     - maxvCpus$
     - minvCpus$
     - state$
@@ -441,7 +441,7 @@ ce:
     - Value$
     - Groups$
     - Key$
-    - Keys$
+    - Keys
     - Metrics$
     - End$
     - NextPageToken$
@@ -683,7 +683,7 @@ cloudwatch:
     - Value$
     - Namespace$
     - NextToken$
-    - OwningAccounts$
+    - OwningAccounts
 codebuild:
   batch_get_builds:
     columns:
@@ -1046,7 +1046,7 @@ ec2:
     columns:
     - ServiceName$
     - State$
-    - SubnetIds$
+    - SubnetIds
     - VpcEndpointId$
     - VpcEndpointType$
     - VpcId$
@@ -1365,12 +1365,12 @@ elasticbeanstalk:
     columns:
     - ApplicationArn$
     - ApplicationName$
-    - ConfigurationTemplates$
+    - ConfigurationTemplates
     - DateCreated$
     - DateUpdated$
     - Description$
     - ResourceLifecycleConfig$
-    - Versions$
+    - Versions
   describe_environment_health:
     columns:
     - EnvironmentName$
@@ -1829,7 +1829,7 @@ kafka:
     - state$
     - creationTime$
     - description$
-    - kafkaVersions$
+    - kafkaVersions
     - latestRevision$
   list_nodes:
     columns:
@@ -2287,7 +2287,7 @@ route53:
     - ResourceRecordSetCount$
     - DelegationSet$
     - CallerReference$
-    - NameServers$
+    - NameServers
     - HostedZone$
   list_health_checks:
     columns:
@@ -2332,10 +2332,10 @@ s3:
     - Permission$
   get_bucket_cors:
     columns:
-    - AllowedOrigins$
-    - AllowedMethods$
-    - AllowedHeaders$
-    - ExposeHeaders$
+    - AllowedOrigins
+    - AllowedMethods
+    - AllowedHeaders
+    - ExposeHeaders
     - MaxAgeSeconds$
   get_bucket_encryption:
     columns:
@@ -2360,7 +2360,7 @@ s3:
   get_bucket_notification_configuration:
     columns:
     - Id$
-    - Events$
+    - Events
     - LambdaFunctionArn$
     - QueueArn$
     - TopicArn$
@@ -2644,8 +2644,7 @@ ssm:
     - Name$
     - DataType$
     - Type$
-    - InvalidParameters$
-    - Parameters$
+    - InvalidParameters
     - LastModifiedDate$
     - Selector$
   list_associations:


### PR DESCRIPTION
## Summary

Closes #14. Depends on #15 (merge sue5t first).

Mechanical follow-up to the sue5t audit. Strip the trailing `$` from 14 default-filter entries that anchor against list-of-primitive fields (and would otherwise match nothing post-flatten), and delete one entry that would degenerate to "match all columns" if the `$` were stripped.

## Fix table

| Service / Operation                                | Entry                 | Fix         | Reason                                                  |
| :------------------------------------------------- | :-------------------- | :---------- | :------------------------------------------------------ |
| `batch.describe_compute_environments`              | `instanceTypes$`      | strip `$`   | flattens to `…instanceTypes.0..N`                       |
| `ce.get_cost_and_usage`                            | `Keys$`               | strip `$`   | flattens to `Groups.Keys.0..N`                          |
| `cloudwatch.list_metrics`                          | `OwningAccounts$`     | strip `$`   | flattens to `OwningAccounts.0..N`                       |
| `ec2.describe_vpc_endpoints`                       | `SubnetIds$`          | strip `$`   | flattens to `SubnetIds.0..N`                            |
| `elasticbeanstalk.describe_applications`           | `ConfigurationTemplates$` | strip `$`   | flattens to `…ConfigurationTemplates.0..N`              |
| `elasticbeanstalk.describe_applications`           | `Versions$`           | strip `$`   | flattens to `…Versions.0..N`                            |
| `kafka.list_configurations`                        | `kafkaVersions$`      | strip `$`   | flattens to `kafkaVersions.0..N`                        |
| `route53.get_hosted_zone`                          | `NameServers$`        | strip `$`   | flattens to `DelegationSet.NameServers.0..N`            |
| `s3.get_bucket_cors`                               | `AllowedOrigins$`     | strip `$`   | flattens to `AllowedOrigins.0..N`                       |
| `s3.get_bucket_cors`                               | `AllowedMethods$`     | strip `$`   | flattens to `AllowedMethods.0..N`                       |
| `s3.get_bucket_cors`                               | `AllowedHeaders$`     | strip `$`   | flattens to `AllowedHeaders.0..N`                       |
| `s3.get_bucket_cors`                               | `ExposeHeaders$`      | strip `$`   | flattens to `ExposeHeaders.0..N`                        |
| `s3.get_bucket_notification_configuration`         | `Events$`             | strip `$`   | flattens to `Events.0..N`                               |
| `ssm.get_parameters`                               | `InvalidParameters$`  | strip `$`   | flattens to `InvalidParameters.0..N`                    |
| `ssm.get_parameters`                               | `Parameters$`         | **delete**  | response root is `Parameters: [...]`; contains-match would match every column (degenerate filter) |

`athena.list_databases Parameters$` was checked and intentionally kept — Athena's `Parameters` is a string-to-string dict (classified `kv_dyn` by the audit, correctly handled by other code paths). Not in scope here.

## Verification

| Gate                                | Result                                                          |
| :---------------------------------- | :-------------------------------------------------------------- |
| `make test`                         | 1307 passed                                                     |
| `make lint`                         | flake8 clean, pylint 10.00/10                                   |
| `make format-check`                 | clean (62 files)                                                |
| `make type-check`                   | clean (12 source files)                                         |
| Audit (run via sue5t's script with `PYTHONPATH` at e1bzl) | all 15 in-scope entries gone from BROKEN list; only sue5t-scope entries remain |

## Dependency on #15

This branch was cut from `main` before #15 (sue5t) merged, so the audit script and its CI test live only on that branch. Once #15 merges:

- This branch's audit-runs-clean test (added in #15) will automatically apply to e1bzl on rebase.
- Until then, CI on this PR validates everything except the audit gate (`make test/lint/format-check/type-check` all green).
- **Please merge #15 first** so the CI history for this PR includes the audit gate.

If you'd rather not rebase, the merge of this PR will fold cleanly into main once #15 is in — there are no conflicts between the two (sue5t fixed 5 different entries + added the audit script; e1bzl fixes 15 different entries in the same YAML file but on non-overlapping lines).

## Test plan

- [ ] CI green on this branch (test + lint suites only — audit gate awaits #15)
- [ ] After merge of #15 + this PR: `python3 scripts/audit_default_filters.py` against main shows `Broken: 0`
- [ ] Manual: `awsquery s3 get-bucket-cors --bucket <name>` shows the four header/method/origin columns populated
- [ ] Manual: `awsquery route53 get-hosted-zone --id <id>` shows `DelegationSet.NameServers.0..N` columns
- [ ] Manual: `awsquery ssm get-parameters --names …` doesn't show a degenerate filter (entry was deleted)
