### PR TITLE
Run quality and test workflows on push to main

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -3,6 +3,8 @@ name: Code Quality
 
 on:
   pull_request:
+  push:
+    branches: [main]
 
 jobs:
   code-quality:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ name: Test Suite
 
 on:
   pull_request:
+  push:
+    branches: [main]
   workflow_call:  # Allow this workflow to be called by other workflows
 
 jobs:


### PR DESCRIPTION
## Summary

Currently, **nothing runs CI on merge to main.** The matrix:

| Workflow      | `pull_request` | `push: main` | `push: v*` tag | `workflow_call` |
| :------------ | :------------- | :----------- | :------------- | :-------------- |
| `quality.yml` | ✓              | ✗            | ✗              | ✗               |
| `test.yml`    | ✓              | ✗            | ✗              | ✓ (called)      |
| `release.yml` | ✗              | ✗            | ✓              | ✗               |

PRs run against a "merge commit preview" of main, not the actual merge commit. If main drifts between PR-CI-pass and merge — out-of-order merges, sneaky conflict resolutions, base branch changes — there's no signal until the next PR opens or the next release tag fires.

This PR adds `push: branches: [main]` to both `quality.yml` and `test.yml` so every commit landing on main gets a fresh CI run.

`workflow_call` on `test.yml` is preserved so `release.yml`'s `jobs.test: uses: ./.github/workflows/test.yml` keeps working.

## Test plan

- [ ] CI green on this PR (validates the trigger doesn't break the existing `pull_request` path)
- [ ] After merge: confirm the workflows fire on the merge-commit push to main and report green
